### PR TITLE
fix typo. NMatix => NMatrix

### DIFF
--- a/lib/numo/gnuplot.rb
+++ b/lib/numo/gnuplot.rb
@@ -419,7 +419,7 @@ class Gnuplot
       elsif defined?(::NArray)
         return true if a.kind_of?(::NArray)
       elsif defined?(::NMatrix)
-        return true if a.kind_of?(::NMatix)
+        return true if a.kind_of?(::NMatrix)
       end
       false
     end


### PR DESCRIPTION
エラーメッセージにNMatixという見慣れない定数が出てきました。
Typoでしょうか。
