### PR TITLE
force add double quotes to string data

### DIFF
--- a/lib/numo/gnuplot.rb
+++ b/lib/numo/gnuplot.rb
@@ -582,7 +582,7 @@ class Gnuplot
           s = v.to_s
           if /"/ =~ s
             kernel_raise GnuplotError,"should not include double quotation in data"
-          elsif / / =~ s
+          else
             s = '"'+s+'"'
           end
         end


### PR DESCRIPTION
issue

``` ruby
require 'numo/gnuplot'

x = ['a','b','c','d','e']
y = [1,2,3,4,5]

Numo.gnuplot do
  set boxwidth:0.5
  set title:"plot with boxes"
  set style:[fill:'solid']
  plot x,y, using:[2,'xtic(1)'], with:'boxes'
end
```

Error

<pre>
Numo::Gnuplot::GnuplotError: 

gnuplot> e
         ^
         line x: invalid command
</pre>


a 1
b 2
c 3
d 4
e 5  <- Gnuplot think it's end-of-input
e

(eから始まる文字列を含めるとエラーが出るようです。よろしくおねがいします。）
