### PR TITLE
Allow new messages of animation GIF

### DIFF
--- a/lib/numo/gnuplot.rb
+++ b/lib/numo/gnuplot.rb
@@ -299,7 +299,7 @@ class Gnuplot
   def run(s,data=nil)
     res = send_cmd(s,data)
     if !res.empty?
-      if /.*?End\sof\sanimation\ssequence.*?/im =~ res.to_s
+      if /.*?(End\sof|frames\sin)\sanimation\ssequence.*?/im =~ res.to_s
         return nil
       end
       if res.size < 7


### PR DESCRIPTION
Recent Gnuplot returns a new message that contains the number of frames in the animation sequence.

Example of message
```
>10 frames in animation sequence
```
