### PR TITLE
A workaround for endless waiting with 5.4 series

### DIFF
--- a/lib/numo/gnuplot.rb
+++ b/lib/numo/gnuplot.rb
@@ -368,6 +368,7 @@ class Gnuplot
     @iow.puts s
     @iow.puts data
     @iow.flush
+    @iow.puts 
     @iow.puts "print '_end_of_cmd_'"
     @iow.flush
     @history << s


### PR DESCRIPTION
Althogh there is no issue with gnuplot 5.2.8, with 5.4.x my script end up with endless waiting without output.  This is a workaround in order to avoid this endless waiting. My environmen is windows gnuplot and cygwin ruby. 

For reference, here is error output when I enter cntrl-C. 

```
      1: from /usr/share/gems/gems/numo-gnuplot-0.2.4/lib/numo/gnuplot.rb:367:in `send_cmd' 
/usr/share/gems/gems/numo-gnuplot-0.2.4/lib/numo/gnuplot.rb:367:in `gets': Interrupt
```


This is a debug information I have with `@debug = true`.

```
<print GPVAL_VERSION
>5.4
<set term pngcairo transparent font "meiryo, 16" size 1280,1600 noenhanced
>
>gnuplot> rint '_end_of_cmd_'
>               ^
>         line 0: invalid command
>
```
